### PR TITLE
CB-26382 Fail if the hostname or domain cannot be set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ build-darwin:
 	GOOS=darwin go build -a -installsuffix cgo ${LDFLAGS} -o build/Darwin_x86_64/${BINARY} main.go
 
 build-linux:
-	GOOS=linux go build -a -installsuffix cgo ${LDFLAGS} -o build/Linux_x86_64/${BINARY} main.go
+	GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo ${LDFLAGS} -o build/Linux_x86_64/${BINARY} main.go
 
 build-linux-arm64:
 	GOOS=linux GOARCH=arm64 go build -a -installsuffix cgo ${LDFLAGS} -o build/Linux_arm64/${BINARY} main.go

--- a/saltboot/hostname.go
+++ b/saltboot/hostname.go
@@ -82,6 +82,7 @@ func ensureHostIsResolvable(customHostname *string, customDomain string, ipv4add
 
 	if err := updateHostsFile(hostName, domain, HOSTS_FILE, ipv4address); err != nil {
 		log.Printf("[ensureHostIsResolvable] [ERROR] unable to update host file: %s", err.Error())
+		return err
 	}
 	networkSysConfig := NETWORK_SYSCONFIG_FILE
 	if isOs(os, SUSE, SLES12) {
@@ -89,9 +90,11 @@ func ensureHostIsResolvable(customHostname *string, customDomain string, ipv4add
 	}
 	if err := updateSysConfig(hostName, domain, networkSysConfig); err != nil {
 		log.Printf("[ensureHostIsResolvable] [ERROR] unable to update sys config: %s", err.Error())
+		return err
 	}
 	if err := updateHostNameFile(hostName, HOSTNAME_FILE); err != nil {
 		log.Printf("[ensureHostIsResolvable] [ERROR] unable to update host name: %s", err.Error())
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
It can happen that the hostname or the domain cannot be set properly, but the Salt minion starts anyways and provides an incorrect minion ID for Cloudbreak. In this case the bootstrap process will eventually fail. To avoid this if the hostname or the domain set commands fail it will report a failure to Cloudbreak and it will retry again until is succeeds.