### PR TITLE
CB-27601: Open port `7071` for HTTPS communication and use it for communication between salt-bootstrap services of the cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BINARY=salt-bootstrap
 
-VERSION=0.13.9
+VERSION=0.14.0
 BUILD_TIME=$(shell date +%FT%T)
 LDFLAGS=-ldflags "-X github.com/hortonworks/salt-bootstrap/saltboot.Version=${VERSION} -X github.com/hortonworks/salt-bootstrap/saltboot.BuildTime=${BUILD_TIME}"
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./.git/*")
@@ -50,7 +50,10 @@ build-docker:
 	docker run --rm ${USER_NS} -v "${PWD}":/go/src/github.com/hortonworks/salt-bootstrap -w /go/src/github.com/hortonworks/salt-bootstrap -e VERSION=${VERSION} golang:1.14.3 make build
 
 build-darwin:
-	GOOS=darwin go build -a -installsuffix cgo ${LDFLAGS} -o build/Darwin_x86_64/${BINARY} main.go
+	GOOS=darwin GOARCH=amd64 go build -a -installsuffix cgo ${LDFLAGS} -o build/Darwin_x86_64/${BINARY} main.go
+
+build-darwin-arm64:
+	GOOS=darwin GOARCH=arm64 go build -a -installsuffix cgo ${LDFLAGS} -o build/Darwin_arm64/${BINARY} main.go
 
 build-linux:
 	GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo ${LDFLAGS} -o build/Linux_x86_64/${BINARY} main.go

--- a/saltboot/netutil_test.go
+++ b/saltboot/netutil_test.go
@@ -10,8 +10,32 @@ func TestDetermineBootstrapPortDefault(t *testing.T) {
 	port := DetermineBootstrapPort()
 
 	if port != defaultPort {
-		t.Errorf("port not match to default %d == %d", defaultPort, port)
+		t.Errorf("port does not match the default port %d == %d", defaultPort, port)
 	}
+}
+
+func TestDetermineBootstrapPortDefaultHttpsFalse(t *testing.T) {
+	os.Setenv(httpsEnabledKey, "false")
+
+	port := DetermineBootstrapPort()
+
+	if port != defaultPort {
+		t.Errorf("port does not match the default port %d == %d", defaultPort, port)
+	}
+
+	os.Unsetenv(httpsEnabledKey)
+}
+
+func TestDetermineBootstrapPortDefaultHttps(t *testing.T) {
+	os.Setenv(httpsEnabledKey, "true")
+
+	port := DetermineBootstrapPort()
+
+	if port != defaultHttpsPort {
+		t.Errorf("port does not match the HTTPS default port %d == %d", defaultHttpsPort, port)
+	}
+
+	os.Unsetenv(httpsEnabledKey)
 }
 
 func TestDetermineBootstrapPortCustom(t *testing.T) {
@@ -20,8 +44,104 @@ func TestDetermineBootstrapPortCustom(t *testing.T) {
 	port := DetermineBootstrapPort()
 
 	if port != 8080 {
-		t.Errorf("port not match to default %d == %d", 8080, port)
+		t.Errorf("port does not match the custom port %d == %d", 8080, port)
 	}
+
+	os.Unsetenv(portKey)
+}
+
+func TestDetermineBootstrapPortCustomHttps(t *testing.T) {
+	os.Setenv(httpsEnabledKey, "true")
+	os.Setenv(httpsPortKey, "8080")
+
+	port := DetermineBootstrapPort()
+
+	if port != 8080 {
+		t.Errorf("port does not match the custom HTTPS port %d == %d", 8080, port)
+	}
+
+	os.Unsetenv(httpsEnabledKey)
+	os.Unsetenv(httpsPortKey)
+}
+
+func TestDetermineHttpsPortDefault(t *testing.T) {
+	port := DetermineHttpsPort()
+
+	if port != defaultHttpsPort {
+		t.Errorf("port does not match the default HTTPS port %d == %d", defaultHttpsPort, port)
+	}
+}
+
+func TestDetermineHttpsPortCustom(t *testing.T) {
+	os.Setenv(httpsPortKey, "8080")
+
+	port := DetermineHttpsPort()
+
+	if port != 8080 {
+		t.Errorf("port does not match the custom HTTPS port %d == %d", 8080, port)
+	}
+
+	os.Unsetenv(httpsPortKey)
+}
+
+func TestDetermineHttpPortDefault(t *testing.T) {
+	port := DetermineHttpPort()
+
+	if port != defaultPort {
+		t.Errorf("port does not match the default port %d == %d", defaultPort, port)
+	}
+}
+
+func TestDetermineHttpPortCustom(t *testing.T) {
+	os.Setenv(portKey, "8080")
+
+	port := DetermineHttpPort()
+
+	if port != 8080 {
+		t.Errorf("port does not match the custom port %d == %d", 8080, port)
+	}
+
+	os.Unsetenv(portKey)
+}
+
+func TestGetHttpsConfigDefault(t *testing.T) {
+	httpsConfig := GetHttpsConfig()
+
+	if httpsConfig.CertFile != defaultHttpsCertFile {
+		t.Errorf("cert file does not match the default %s == %s", defaultHttpsCertFile, httpsConfig.CertFile)
+	}
+	if httpsConfig.KeyFile != defaultHttpsKeyFile {
+		t.Errorf("key file does not match the default %s == %s", defaultHttpsKeyFile, httpsConfig.KeyFile)
+	}
+	if httpsConfig.CaCertFile != defaultHttpsCaCertFileKey {
+		t.Errorf("ca cert file does not match the default %s == %s", defaultHttpsCaCertFileKey, httpsConfig.CaCertFile)
+	}
+}
+
+func TestGetHttpsConfigCustom(t *testing.T) {
+	os.Setenv(httpsCertFileKey, "path/certfile.pem")
+	os.Setenv(httpsKeyFileKey, "path/keyfile.pem")
+	os.Setenv(httpsCaCertFileKey, "path/ca.pem")
+
+	httpsConfig := GetHttpsConfig()
+
+	if httpsConfig.CertFile != "path/certfile.pem" {
+		t.Errorf("cert file does not match the default %s == %s", "path/certfile.pem", httpsConfig.CertFile)
+	}
+	if httpsConfig.KeyFile != "path/keyfile.pem" {
+		t.Errorf("key file does not match the default %s == %s", "path/keyfile.pem", httpsConfig.KeyFile)
+	}
+	if httpsConfig.CaCertFile != "path/ca.pem" {
+		t.Errorf("ca cert file does not match the default %s == %s", "path/ca.pem", httpsConfig.CaCertFile)
+	}
+
+	os.Unsetenv(httpsCertFileKey)
+	os.Unsetenv(httpsKeyFileKey)
+	os.Unsetenv(httpsCaCertFileKey)
+}
+
+func TestGetConcatenatedCertFilePath(t *testing.T) {
+
 }
 
 func TestConfigfileFoundByEnv(t *testing.T) {

--- a/saltboot/web.go
+++ b/saltboot/web.go
@@ -2,10 +2,9 @@ package saltboot
 
 import (
 	"fmt"
+	"github.com/gorilla/mux"
 	"log"
 	"net/http"
-
-	"github.com/gorilla/mux"
 )
 
 const (
@@ -32,7 +31,6 @@ const (
 )
 
 func NewCloudbreakBootstrapWeb() {
-	address := fmt.Sprintf(":%d", DetermineBootstrapPort())
 	log.Println("[web] NewCloudbreakBootstrapWeb")
 
 	authenticator := Authenticator{}
@@ -62,9 +60,34 @@ func NewCloudbreakBootstrapWeb() {
 	r.Handle(UploadEP, authenticator.Wrap(FileUploadHandler, SIGNED)).Methods("POST")
 	r.Handle(FileDistributeEP, authenticator.Wrap(FileUploadDistributeHandler, SIGNED)).Methods("POST")
 
-	log.Printf("[web] starting server at: %s", address)
 	http.Handle("/", r)
-	if err := http.ListenAndServe(address, nil); err != nil {
+
+	httpsEnabled := HttpsEnabled()
+	httpsServerExit := make(chan bool)
+	if httpsEnabled {
+		go func() {
+			httpsAddress := fmt.Sprintf(":%d", DetermineHttpsPort())
+			httpsConfig := GetHttpsConfig()
+			concCertFile, err := GetConcatenatedCertFilePath(httpsConfig)
+			if err != nil {
+				log.Printf("[web] Could not concatenate the server cert and ca cert: %v", err)
+			} else {
+				log.Printf("[web] starting server at address: %s", httpsAddress)
+				if err = http.ListenAndServeTLS(httpsAddress, concCertFile, httpsConfig.KeyFile, nil); err != nil {
+					log.Printf("[web] [ERROR] unable to ListenAndServeTLS: %s", err.Error())
+				}
+				httpsServerExit <- true
+			}
+		}()
+	}
+
+	httpAddress := fmt.Sprintf(":%d", DetermineHttpPort())
+	log.Printf("[web] starting server at address: %s", httpAddress)
+	if err := http.ListenAndServe(httpAddress, nil); err != nil {
 		log.Printf("[web] [ERROR] unable to ListenAndServe: %s", err.Error())
+	}
+
+	if httpsEnabled {
+		<-httpsServerExit
 	}
 }


### PR DESCRIPTION
- Currently there is neither client- nor server-side validation of certificates, TLS is only used to ensure the communication is encrypted
- The server is provided the same certs used by nginx under `/etc/certs`, but these don't serve a purpose as client-side validation is turned off for the clients
- The `7070` port remains open for HTTP communication
- The communication between nginx and salt-bootstrap still uses the non-TLS `7070` port, as this is an internal call on the machine