### PR TITLE
CB-28539: Clone the default HTTP Transport for the HTTPS Transport

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BINARY=salt-bootstrap
 
-VERSION=0.14.1
+VERSION=0.14.2
 BUILD_TIME=$(shell date +%FT%T)
 LDFLAGS=-ldflags "-X github.com/hortonworks/salt-bootstrap/saltboot.Version=${VERSION} -X github.com/hortonworks/salt-bootstrap/saltboot.BuildTime=${BUILD_TIME}"
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./.git/*")

--- a/saltboot/distributor.go
+++ b/saltboot/distributor.go
@@ -30,12 +30,14 @@ func determineProtocol(httpsEnabled bool) string {
 
 func getHttpClient(httpsEnabled bool) *http.Client {
 	if httpsEnabled {
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		if transport.TLSClientConfig == nil {
+			transport.TLSClientConfig = &tls.Config{}
+		}
+		transport.TLSClientConfig.InsecureSkipVerify = true
+
 		return &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: true,
-				},
-			},
+			Transport: transport,
 		}
 	} else {
 		return &http.Client{}


### PR DESCRIPTION
We need to copy the Transport struct used in the default HTTP client, as the default Transport has several timeout values set, which we need to copy if we want to have the same behaviour as with HTTP disabled.